### PR TITLE
Extract test name from metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,11 @@ FROM sbtscala/scala-sbt:eclipse-temurin-17.0.4_1.7.2_2.13.10
 
 WORKDIR /opt/test-runner
 
+ENV CONFIG_PATH '.meta'
+
+RUN apt-get update
+RUN apt-get install --yes jq
+
 COPY project/ project/
 COPY src/ src/
 COPY build.sbt build.sbt

--- a/bin/run-in-docker.sh
+++ b/bin/run-in-docker.sh
@@ -41,4 +41,5 @@ docker run \
     --mount type=bind,src="${input_dir}",dst=/solution \
     --mount type=bind,src="${output_dir}",dst=/output \
     --mount type=tmpfs,dst=/tmp \
+    --env CONFIG_PATH="${CONFIG_PATH}" \
     exercism/test-runner "${slug}" /solution /output 


### PR DESCRIPTION
Fixes https://github.com/exercism/scala-test-runner/issues/36

- parse .meta/config.json
- allow overriding `.meta` path for local testing
- fallback to exercise slug if not exists
- fallback to exercise slug if multiple test files
- set workdir_target to "${workdir}/target"
